### PR TITLE
Allow Dependency Containers as children of Panels

### DIFF
--- a/src/HasDependencies.php
+++ b/src/HasDependencies.php
@@ -14,7 +14,8 @@ trait HasDependencies
      */
     public function availableFields(NovaRequest $request)
     {
-        $fields = $this->fields($request);
+        // Needs to be filtered once to resolve Panels
+        $fields = $this->filter($this->fields($request));
         $availableFields = [];
 
         foreach ($fields as $field) {
@@ -34,10 +35,11 @@ trait HasDependencies
     /**
      * @return bool
      */
-    protected function doesRouteRequireChildFields(): bool
+    protected function doesRouteRequireChildFields() : bool
     {
         return ends_with(Route::currentRouteAction(), 'AssociatableController@index')
             || ends_with(Route::currentRouteAction(), 'ResourceStoreController@handle')
-            || ends_with(Route::currentRouteAction(), 'ResourceUpdateController@handle');
+            || ends_with(Route::currentRouteAction(), 'ResourceUpdateController@handle')
+            || ends_with(Route::currentRouteAction(), 'FieldDestroyController@handle');
     }
 }


### PR DESCRIPTION
This also fixes a bug where File fields inside Dependency Containers can't be deleted in frontend (throws 404)