### PR TITLE
Respect "after save" callbacks

### DIFF
--- a/src/NovaDependencyContainer.php
+++ b/src/NovaDependencyContainer.php
@@ -106,8 +106,26 @@ class NovaDependencyContainer extends Field
      */
     protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
     {
-        foreach ($this->meta['fields'] as $field) {
-            $field->fill($request, $model);
+        $callbacks = [];
+
+        foreach ($this->meta[ 'fields' ] as $field) {
+
+            $callbacks[] = $field->fill($request, $model);
+
         }
+
+        return function () use ($callbacks) {
+
+            foreach ($callbacks as $key => $callback) {
+
+                if ($callback instanceof \Closure) {
+
+                    call_user_func($callback);
+
+                }
+
+            }
+
+        };       
     }
 }

--- a/src/NovaDependencyContainer.php
+++ b/src/NovaDependencyContainer.php
@@ -116,7 +116,7 @@ class NovaDependencyContainer extends Field
 
         return function () use ($callbacks) {
 
-            foreach ($callbacks as $key => $callback) {
+            foreach ($callbacks as $callback) {
 
                 if ($callback instanceof \Closure) {
 


### PR DESCRIPTION
Hi, many third parties packages uses this after save logic to do extra work after the main model id is known.

This PR should fix an issue where [advanced-nova-media-library](https://github.com/ebess/advanced-nova-media-library) package doesn't work at all when inserted inside the dependency-container field.

**NO** breaking changes were introduced and a few packages out there that relies on this nova feature should start to work properly with this package.