### PR TITLE
Bail processing fields if it doesn't satisfy its constraints 

### DIFF
--- a/src/NovaDependencyContainer.php
+++ b/src/NovaDependencyContainer.php
@@ -106,30 +106,14 @@ class NovaDependencyContainer extends Field
      */
     protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
     {
-        $callbacks = [];
-
         if (!HasDependencies::doesFieldSatisfyConstraints($this, $request)) {
             return;
         }
 
         foreach ($this->meta[ 'fields' ] as $field) {
 
-            $callbacks[] = $field->fill($request, $model);
+            $field->fill($request, $model);
 
         }
-
-        return function () use ($callbacks) {
-
-            foreach ($callbacks as $callback) {
-
-                if ($callback instanceof \Closure) {
-
-                    call_user_func($callback);
-
-                }
-
-            }
-
-        };
     }
 }

--- a/src/NovaDependencyContainer.php
+++ b/src/NovaDependencyContainer.php
@@ -106,8 +106,26 @@ class NovaDependencyContainer extends Field
      */
     protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
     {
-        foreach ($this->meta['fields'] as $field) {
-            $field->fill($request, $model);
+        $callbacks = [];
+
+        foreach ($this->meta[ 'fields' ] as $field) {
+
+            $callbacks[] = $field->fill($request, $model);
+
         }
+
+        return function () use ($callbacks) {
+
+            foreach ($callbacks as $key => $callback) {
+
+                if ($callback instanceof \Closure) {
+
+                    call_user_func($callback);
+
+                }
+
+            }
+
+        };       
     }
 }

--- a/src/NovaDependencyContainer.php
+++ b/src/NovaDependencyContainer.php
@@ -95,25 +95,4 @@ class NovaDependencyContainer extends Field
 
         return [];
     }
-
-    /**
-     * Fills the attributes of the model within the container if the dependencies for the container are satisfied.
-     *
-     * @param NovaRequest $request
-     * @param string $requestAttribute
-     * @param object $model
-     * @param string $attribute
-     */
-    protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
-    {
-        if (!HasDependencies::doesFieldSatisfyConstraints($this, $request)) {
-            return;
-        }
-
-        foreach ($this->meta[ 'fields' ] as $field) {
-
-            $field->fill($request, $model);
-
-        }
-    }
 }

--- a/src/NovaDependencyContainer.php
+++ b/src/NovaDependencyContainer.php
@@ -107,6 +107,30 @@ class NovaDependencyContainer extends Field
     protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
     {
         $callbacks = [];
+        $satisfied = false;
+
+        /**
+         * Check if any constrain has been satisfied otherwise bail the execution,
+         * if user has multiple instances of NovaDependencyContainer::make()
+         * this ensure only the one that has been satisfied is filled
+         */
+        foreach ($this->meta[ 'dependencies' ] as $dependency) {
+
+            $inputValue = $request->input($dependency[ 'field' ]);
+
+            if (array_key_exists('notEmpty', $dependency) && !is_null($inputValue) || $inputValue == $dependency[ 'value' ]) {
+
+                $satisfied = true;
+
+            }
+
+        }
+
+        if (!$satisfied) {
+
+            return;
+
+        }
 
         foreach ($this->meta[ 'fields' ] as $field) {
 
@@ -126,6 +150,6 @@ class NovaDependencyContainer extends Field
 
             }
 
-        };       
+        };
     }
 }

--- a/src/NovaDependencyContainer.php
+++ b/src/NovaDependencyContainer.php
@@ -107,29 +107,9 @@ class NovaDependencyContainer extends Field
     protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
     {
         $callbacks = [];
-        $satisfied = false;
 
-        /**
-         * Check if any constrain has been satisfied otherwise bail the execution,
-         * if user has multiple instances of NovaDependencyContainer::make()
-         * this ensure only the one that has been satisfied is filled
-         */
-        foreach ($this->meta[ 'dependencies' ] as $dependency) {
-
-            $inputValue = $request->input($dependency[ 'field' ]);
-
-            if (array_key_exists('notEmpty', $dependency) && !is_null($inputValue) || $inputValue == $dependency[ 'value' ]) {
-
-                $satisfied = true;
-
-            }
-
-        }
-
-        if (!$satisfied) {
-
+        if (!HasDependencies::doesFieldSatisfyConstraints($this, $request)) {
             return;
-
         }
 
         foreach ($this->meta[ 'fields' ] as $field) {

--- a/src/NovaDependencyContainer.php
+++ b/src/NovaDependencyContainer.php
@@ -116,7 +116,7 @@ class NovaDependencyContainer extends Field
 
         return function () use ($callbacks) {
 
-            foreach ($callbacks as $key => $callback) {
+            foreach ($callbacks as $callback) {
 
                 if ($callback instanceof \Closure) {
 


### PR DESCRIPTION
Hi this PR fixes issues caused if there are multiple instances of nova-dependency-container on the same resource, for example:

```php
public function fields(Request $request)
{
    return [

        Select::make('Type')->options([
            'a' => 'A',
            'b' => 'B',
            'c' => 'C',
        ]),

        NovaDependencyContainer::make(...)->dependsOn('type', 'a'),
        NovaDependencyContainer::make(...)->dependsOn('type', 'b'),
        NovaDependencyContainer::make(...)->dependsOn('type', 'c'),

    ];
}
```

In the example above using the current version every `NovaDependencyContainer` will be called on save, so if for example `type === a` and the dependency `b` has some fields which are required, nova will fail because the required field is not input / is missing

This PR checks if the constants on `type === ?` is truthy otherwise bail / ignore the  NovaDependencyContainer, in other words ignore the `b` and `c` if `type === a`

Ultimately this fix a hard issue with this package: https://github.com/whitecube/nova-flexible-content, that only occurs if you have multiple versions of `NovaDependencyContainer`