### PR TITLE
 Check resource before getting morphto attributes

### DIFF
--- a/src/NovaDependencyContainer.php
+++ b/src/NovaDependencyContainer.php
@@ -4,11 +4,10 @@ namespace Epartment\NovaDependencyContainer;
 
 use Epartment\NovaDependencyContainer\Contracts\NPCS\ReinitAfterCloned;
 use Epartment\NovaDependencyContainer\Concerns\NPCS\HandlesReinitAfterCloned;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Log;
 use Laravel\Nova\Fields\Field;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Illuminate\Support\Str;
+use Laravel\Nova\Resource;
 
 class NovaDependencyContainer extends Field
 
@@ -206,11 +205,13 @@ class NovaDependencyContainer extends Field
                     continue;
                 }
 
-                // @todo: quickfix for MorphTo
-                $morphable_attribute = $resource->getAttribute($dependency['property'].'_type');
-                if ($morphable_attribute !== null && Str::endsWith($morphable_attribute, '\\'.$dependency['value'])) {
-                    $this->meta['dependencies'][$index]['satisfied'] = true;
-                    continue;
+                if ($resource instanceof Resource) {
+                    // @todo: quickfix for MorphTo
+                    $morphable_attribute = $resource->getAttribute($dependency['property'] . '_type');
+                    if ($morphable_attribute !== null && Str::endsWith($morphable_attribute, '\\' . $dependency['value'])) {
+                        $this->meta['dependencies'][$index]['satisfied'] = true;
+                        continue;
+                    }
                 }
             }
 


### PR DESCRIPTION
Following up with my comment in #102 to make this compatible with whitecube/nova-flexible-content. When resolving for display the `$resource` attribute isn't a `Laravel\Nova\Resource` if the dependancy container field was used in flexible content. Just added a check before it attempts to retrieve MorphTo attributes. Also removed a couple of unused class imports.