### PR TITLE
Leverage Nova 3.1 separate method fields

### DIFF
--- a/src/HasDependencies.php
+++ b/src/HasDependencies.php
@@ -17,8 +17,14 @@ trait HasDependencies
      */
     public function availableFields(NovaRequest $request)
     {
+        if (method_exists($this, 'fieldsMethod')) {
+            $method = $this->fieldsMethod($request);
+        } else {
+            $method = 'fields';
+        }
+
         // needs to be filtered once to resolve Panels
-        $fields = $this->filter($this->fields($request));
+        $fields = $this->filter($this->{$method}($request));
         $availableFields = [];
 
         foreach ($fields as $field) {


### PR DESCRIPTION
Nova 3.1 introduced the ability to split fields declaration in separate methods (fieldsForIndex, FieldsForDetail, FieldsForCreate, fieldsForUpdate).
This PR add support to these new methods.