### PR TITLE
Make method signature compatible again

### DIFF
--- a/src/HasDependencies.php
+++ b/src/HasDependencies.php
@@ -9,11 +9,12 @@ use Laravel\Nova\Fields\Field;
 use Laravel\Nova\Fields\FieldCollection;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Fields\MorphTo;
+use Laravel\Nova\Http\Requests\ActionRequest;
 
 trait HasDependencies
 {
     protected $childFieldsArr = [];
-    
+
     /**
      * @param NovaRequest $request
      * @return FieldCollection|\Illuminate\Support\Collection
@@ -139,9 +140,10 @@ trait HasDependencies
     /**
      * Validate action fields
      * Overridden using ActionController & ActionRequest by modifying routes
+     * @param  \Laravel\Nova\Http\Requests\ActionRequest  $request
      * @return void
      */
-    public function validateFields() {
+    public function validateFields(ActionRequest $request = null) {
         $availableFields = [];
         if ( !empty( ($action_fields = $this->action()->fields()) ) ) {
             foreach ($action_fields as $field) {


### PR DESCRIPTION
This PR makes the method signature of `validateFields` compatible again with the definition in nova 3.21.0.

Have not tested functionality changes, but my implementations are still working.
Have not tested against older versions of nova, but this way of overriding the method should be compatible.

Resolves #149 