### PR TITLE
Use data_get to retrieve value from resource

### DIFF
--- a/src/NovaDependencyContainer.php
+++ b/src/NovaDependencyContainer.php
@@ -150,31 +150,32 @@ class NovaDependencyContainer extends Field
         }
 
         foreach ($this->meta['dependencies'] as $index => $dependency) {
-
             $this->meta['dependencies'][$index]['satisfied'] = false;
 
-            if (array_key_exists('empty', $dependency) && empty($resource->{$dependency['property']})) {
+            $value = data_get($resource, str_replace('->', '.', $dependency['property']));
+
+            if (array_key_exists('empty', $dependency) && empty($value)) {
                 $this->meta['dependencies'][$index]['satisfied'] = true;
                 continue;
             }
             // inverted `empty()`
-            if (array_key_exists('notEmpty', $dependency) && !empty($resource->{$dependency['property']})) {
+            if (array_key_exists('notEmpty', $dependency) && !empty($value)) {
                 $this->meta['dependencies'][$index]['satisfied'] = true;
                 continue;
             }
             // inverted
-            if (array_key_exists('nullOrZero', $dependency) && in_array($resource->{$dependency['property']}, [null, 0, '0'], true)) {
+            if (array_key_exists('nullOrZero', $dependency) && in_array($value, [null, 0, '0'], true)) {
                 $this->meta['dependencies'][$index]['satisfied'] = true;
                 continue;
             }
 
-            if (array_key_exists('not', $dependency) && $resource->{$dependency['property']} != $dependency['not']) {
+            if (array_key_exists('not', $dependency) && $value != $dependency['not']) {
                 $this->meta['dependencies'][$index]['satisfied'] = true;
                 continue;
             }
 
             if (array_key_exists('value', $dependency)) {
-                if ($dependency['value'] == $resource->{$dependency['property']}) {
+                if ($dependency['value'] == $value) {
                     $this->meta['dependencies'][$index]['satisfied'] = true;
                     continue;
                 }
@@ -185,7 +186,6 @@ class NovaDependencyContainer extends Field
                     continue;
                 }
             }
-
         }
     }
 


### PR DESCRIPTION
Using Laravel's `data_get` helper allows nested values to be used for the dependencies, which is important for packages like Nova Page Manager where all the fields are stored in a `data` JSON column (that is casted into an array in the model). This allows dependencies on field attributes such as `data->type`. This PR does not introduce any breaking changes and does not affect existing setups.