### PR TITLE
break out traits to fix Action vs ActionRequest usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ composer require epartment/nova-dependency-container
 
 1. Add the `Epartment\NovaDependencyContainer\HasDependencies` trait to your Nova Resource.
 2. Add the `Epartment\NovaDependencyContainer\NovaDependencyContainer` to your Nova Resource `fields` method.
+3. Add the `Epartment\NovaDependencyContainer\ActionHasDependencies` trait to your Nova Actions that you wish to use dependencies on.
 
 ```php
 class Page extends Resource

--- a/src/ActionHasDependencies.php
+++ b/src/ActionHasDependencies.php
@@ -1,26 +1,25 @@
 <?php
 
-namespace Epartment\NovaDependencyContainer\Http\Requests;
+namespace Epartment\NovaDependencyContainer;
 
-use Epartment\NovaDependencyContainer\HasDependencies;
-use Laravel\Nova\Http\Requests\ActionRequest as NovaActionRequest;
-
-class ActionRequest extends NovaActionRequest {
-
-    use HasDependencies;
+trait ActionHasDependencies
+{
+    use HasChildFields;
 
     /**
-     * Handles child fields.
+     * Validate action fields
      *
+     * @param  \Laravel\Nova\Http\Requests\ActionRequest  $request
      * @return void
      */
-    public function validateFields() {
+    public function validateFields(ActionRequest $request)
+    {
         $availableFields = [];
 
-        foreach ($this->action()->fields() as $field) {
+        foreach ($request->action()->fields() as $field) {
             if ($field instanceof NovaDependencyContainer) {
                 // do not add any fields for validation if container is not satisfied
-                if ($field->areDependenciesSatisfied($this)) {
+                if($field->areDependenciesSatisfied($this)) {
                     $availableFields[] = $field;
                     $this->extractChildFields($field->meta['fields']);
                 }

--- a/src/ActionHasDependencies.php
+++ b/src/ActionHasDependencies.php
@@ -18,7 +18,7 @@ trait ActionHasDependencies
     {
         $availableFields = [];
 
-        foreach ($request->action()->fields() as $field) {
+        foreach ($this->fields() as $field) {
             if ($field instanceof NovaDependencyContainer) {
                 // do not add any fields for validation if container is not satisfied
                 if($field->areDependenciesSatisfied($this)) {

--- a/src/ActionHasDependencies.php
+++ b/src/ActionHasDependencies.php
@@ -2,6 +2,8 @@
 
 namespace Epartment\NovaDependencyContainer;
 
+use Laravel\Nova\Http\Requests\ActionRequest;
+
 trait ActionHasDependencies
 {
     use HasChildFields;

--- a/src/HasChildFields.php
+++ b/src/HasChildFields.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Epartment\NovaDependencyContainer;
+
+trait HasChildFields
+{
+    protected $childFieldsArr = [];
+
+    /**
+     * @param  [array] $childFields [meta fields]
+     * @return void
+     */
+    protected function extractChildFields($childFields)
+    {
+        foreach ($childFields as $childField) {
+            if ($childField instanceof NovaDependencyContainer) {
+                $this->extractChildFields($childField->meta['fields']);
+            } else {
+                if (array_search($childField->attribute, array_column($this->childFieldsArr, 'attribute')) === false) {
+                    // @todo: we should not randomly apply rules to child-fields.
+                    $childField = $this->applyRulesForChildFields($childField);
+                    $this->childFieldsArr[] = $childField;
+                }
+            }
+        }
+    }
+
+    /**
+     * @param  [array] $childField
+     * @return [array] $childField
+     */
+    protected function applyRulesForChildFields($childField)
+    {
+        if (isset($childField->rules)) {
+            $childField->rules[] = "sometimes:required:".$childField->attribute;
+        }
+        if (isset($childField->creationRules)) {
+            $childField->creationRules[] = "sometimes:required:".$childField->attribute;
+        }
+        if (isset($childField->updateRules)) {
+            $childField->updateRules[] = "sometimes:required:".$childField->attribute;
+        }
+        return $childField;
+    }
+}

--- a/src/HasDependencies.php
+++ b/src/HasDependencies.php
@@ -2,13 +2,9 @@
 
 namespace Epartment\NovaDependencyContainer;
 
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
-use Laravel\Nova\Fields\Field;
 use Laravel\Nova\Fields\FieldCollection;
-use Laravel\Nova\Fields\MorphTo;
-use Laravel\Nova\Http\Requests\ActionRequest;
 use Laravel\Nova\Http\Requests\NovaRequest;
 
 trait HasDependencies
@@ -16,8 +12,8 @@ trait HasDependencies
     use HasChildFields;
 
     /**
-     * @param NovaRequest $request
-     * @return FieldCollection|\Illuminate\Support\Collection
+     * @param  NovaRequest  $request
+     * @return FieldCollection
      */
     public function availableFields(NovaRequest $request)
     {
@@ -42,33 +38,36 @@ trait HasDependencies
             $availableFields = array_merge($availableFields, $this->childFieldsArr);
         }
 
-
         $availableFields = new FieldCollection(array_values($this->filter($availableFields)));
+
         return $availableFields;
     }
 
     /**
      * Check if request needs to extract child fields
      *
-     * @param NovaRequest $request
-     * @param $model
+     * @param  NovaRequest  $request
+     * @param  mixed  $model
      * @return bool
      */
-    protected function extractableRequest(NovaRequest $request, $model) {
+    protected function extractableRequest(NovaRequest $request, $model)
+    {
         // if form was submitted to update (method === 'PUT')
-        if($request->isUpdateOrUpdateAttachedRequest() && strtoupper($request->get('_method', null)) === 'PUT') {
+        if ($request->isUpdateOrUpdateAttachedRequest() && $request->method() == 'PUT') {
             return false;
         }
+
         // if form was submitted to create and new resource
-        if($request->isCreateOrAttachRequest() && $model->id === null) {
+        if ($request->isCreateOrAttachRequest() && $model->id === null) {
             return false;
         }
+
         return true;
     }
 
     /**
-     * @param $field
-     * @param NovaRequest $request
+     * @param  mixed  $field
+     * @param  NovaRequest  $request
      * @return mixed
      *
      * @todo: implement
@@ -76,14 +75,6 @@ trait HasDependencies
     public function filterFieldForRequest($field, NovaRequest $request) {
         // @todo: filter fields for request, e.g. show/hideOnIndex, create, update or whatever
         return $field;
-    }
-
-    /**
-     * @param array $availableFields
-     * @param NovaRequest $request
-     */
-    public function filterFieldsForRequest(Collection $availableFields, NovaRequest $request) {
-        return $availableFields;
     }
 
     /**

--- a/src/Http/Controllers/ActionController.php
+++ b/src/Http/Controllers/ActionController.php
@@ -3,6 +3,7 @@
 namespace Epartment\NovaDependencyContainer\Http\Controllers;
 
 use Epartment\NovaDependencyContainer\Http\Requests\ActionRequest;
+use Laravel\Nova\Http\Requests\ActionRequest as NovaActionRequest;
 use Laravel\Nova\Http\Controllers\ActionController as NovaActionController;
 
 class ActionController extends NovaActionController
@@ -14,8 +15,10 @@ class ActionController extends NovaActionController
 	 * @param  \Laravel\Nova\Http\Requests\ActionRequest  $request
 	 * @return \Illuminate\Http\Response
 	 */
-    public function store(ActionRequest $request)
+    public function store(NovaActionRequest $request)
     {
+        $request = ActionRequest::createFrom($request);
+
         return parent::store($request);
 	}
 }

--- a/src/Http/Controllers/ActionController.php
+++ b/src/Http/Controllers/ActionController.php
@@ -8,17 +8,17 @@ use Laravel\Nova\Http\Controllers\ActionController as NovaActionController;
 
 class ActionController extends NovaActionController
 {
-	/**
+    /**
      * This uses the custom ActionRequest typehint to enable
      * dependency features.
-	 *
-	 * @param  \Laravel\Nova\Http\Requests\ActionRequest  $request
-	 * @return \Illuminate\Http\Response
-	 */
+     *
+     * @param  \Laravel\Nova\Http\Requests\ActionRequest  $request
+     * @return \Illuminate\Http\Response
+     */
     public function store(NovaActionRequest $request)
     {
         $request = ActionRequest::createFrom($request);
 
         return parent::store($request);
-	}
+    }
 }

--- a/src/Http/Controllers/ActionController.php
+++ b/src/Http/Controllers/ActionController.php
@@ -9,8 +9,7 @@ use Laravel\Nova\Http\Controllers\ActionController as NovaActionController;
 class ActionController extends NovaActionController
 {
     /**
-     * This uses the custom ActionRequest typehint to enable
-     * dependency features.
+     * create custom request from base Nova ActionRequest
      *
      * @param  \Laravel\Nova\Http\Requests\ActionRequest  $request
      * @return \Illuminate\Http\Response

--- a/src/Http/Controllers/ActionController.php
+++ b/src/Http/Controllers/ActionController.php
@@ -3,37 +3,19 @@
 namespace Epartment\NovaDependencyContainer\Http\Controllers;
 
 use Epartment\NovaDependencyContainer\Http\Requests\ActionRequest;
-use Illuminate\Routing\Controller;
-use Laravel\Nova\Http\Requests\NovaRequest;
+use Laravel\Nova\Http\Controllers\ActionController as NovaActionController;
 
-class ActionController extends Controller {
-
+class ActionController extends NovaActionController
+{
 	/**
-	 * List the actions for the given resource.
-	 *
-	 * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
-	 * @return \Illuminate\Http\Response
-	 */
-	public function index(NovaRequest $request) {
-		return response()->json([
-			'actions' => $request->newResource()->availableActions($request),
-			'pivotActions' => [
-				'name' => $request->pivotName(),
-				'actions' => $request->newResource()->availablePivotActions($request),
-			],
-		]);
-	}
-
-	/**
-	 * Perform an action on the specified resources.
+     * This uses the custom ActionRequest typehint to enable
+     * dependency features.
 	 *
 	 * @param  \Laravel\Nova\Http\Requests\ActionRequest  $request
 	 * @return \Illuminate\Http\Response
 	 */
-	public function store(ActionRequest $request) {
-
-		$request->validateFields();
-
-		return $request->action()->handleRequest($request);
+    public function store(ActionRequest $request)
+    {
+        return parent::store($request);
 	}
 }


### PR DESCRIPTION
This fixes a seemingly outlier issue potentially related to opcache, where the ActionRequest is called on an Action.

The stacktrace here looks something like this:
```
Error Call to undefined method App\Nova\Actions\BulkLocationBrandExclude::action() 
    vendor/epartment/nova-dependency-container/src/HasDependencies.php:148 App\Nova\Actions\BulkLocationBrandExclude::validateFields
    vendor/laravel/nova/src/Http/Requests/ActionRequest.php:150 Laravel\Nova\Http\Requests\ActionRequest::validateFields
    vendor/laravel/nova/src/Http/Controllers/ActionController.php:42 Laravel\Nova\Http\Controllers\ActionController::store
```

The issue is that the validateFields function potentially used on on Action, doesn't properly handle that an action doesn't need to call `$this->action()->fields()` and instead could call `$this->fields()` directly.

This PR breaks up the monolithic HasDependencies into multiple smaller traits, and specifically documents how to use the Dependency Container in an Action.

Maybe this is actually enabling using dependency on  actions