### PR TITLE
Use loose equality for dependsOnNot

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -128,7 +128,7 @@
 						return;
 					}
 
-					if (dependency.hasOwnProperty('not') && dependencyValue !== dependency.not) {
+					if (dependency.hasOwnProperty('not') && dependencyValue != dependency.not) {
 						this.dependenciesSatisfied = true;
 						return;
 					}


### PR DESCRIPTION
dependsOnNot doesn't work with integer because html select list options return strings causing the strict equality to fail. With loose equality a `dependsOnNot('key', 11)` will now match `<options value="11">`

fixes epartment/nova-dependency-container#121