### PR TITLE
Allow post-hydration callbacks to run

### DIFF
--- a/src/NovaDependencyContainer.php
+++ b/src/NovaDependencyContainer.php
@@ -215,9 +215,17 @@ class NovaDependencyContainer extends Field
      */
     public function fillInto(NovaRequest $request, $model, $attribute, $requestAttribute = null)
     {
-        foreach($this->meta['fields'] as $field) {
-            $field->fill($request, $model);
-        }
+        $callbacks = collect($this->meta['fields'])
+            ->map(function ($field) use ($request, $model) {
+                return $field->fill($request, $model);
+            })
+            ->filter('is_callable');
+
+        return function () use ($callbacks) {
+            $callbacks->each(function ($callback) {
+                call_user_func($callback);
+            });
+        };
     }
 
     /**

--- a/src/NovaDependencyContainer.php
+++ b/src/NovaDependencyContainer.php
@@ -212,6 +212,7 @@ class NovaDependencyContainer extends Field
      * @param $model
      * @param $attribute
      * @param null $requestAttribute
+     * @return callable
      */
     public function fillInto(NovaRequest $request, $model, $attribute, $requestAttribute = null)
     {


### PR DESCRIPTION
A field's `fill()` method can return a callback which will run after the model is hydrated. However, this is currently ignored by NovaDependencyContainer. This stops other custom fields such as [Advanced Nova Media Library](https://github.com/ebess/advanced-nova-media-library) from being used with this field.

This change takes the return value of each field, filters anything that is callable, and returns a function which will then run all those callbacks.