### PR TITLE
Fixes validation for Nova Actions

### DIFF
--- a/src/ActionHasDependencies.php
+++ b/src/ActionHasDependencies.php
@@ -28,6 +28,8 @@ trait ActionHasDependencies
         if ($this->childFieldsArr) {
             $availableFields = array_merge($availableFields, $this->childFieldsArr);
         }
+        
+        return $availableFields;
     }
 
     /**

--- a/src/Http/Requests/ActionRequest.php
+++ b/src/Http/Requests/ActionRequest.php
@@ -6,36 +6,5 @@ use Epartment\NovaDependencyContainer\HasDependencies;
 use Epartment\NovaDependencyContainer\NovaDependencyContainer;
 use Laravel\Nova\Http\Requests\ActionRequest as NovaActionRequest;
 
-class ActionRequest extends NovaActionRequest {
-
-    use HasDependencies;
-
-    /**
-     * Handles child fields.
-     *
-     * @return void
-     */
-    public function validateFields() {
-        $availableFields = [];
-
-        foreach ($this->action()->fields() as $field) {
-            if ($field instanceof NovaDependencyContainer) {
-                // do not add any fields for validation if container is not satisfied
-                if ($field->areDependenciesSatisfied($this)) {
-                    $availableFields[] = $field;
-                    $this->extractChildFields($field->meta['fields']);
-                }
-            } else {
-                $availableFields[] = $field;
-            }
-        }
-
-        if ($this->childFieldsArr) {
-            $availableFields = array_merge($availableFields, $this->childFieldsArr);
-        }
-
-        $this->validate(collect($availableFields)->mapWithKeys(function ($field) {
-            return $field->getCreationRules($this);
-        })->all());
-    }
+class ActionRequest extends NovaActionRequest {    
 }


### PR DESCRIPTION
Even when actions use the trait `ActionHasDependencies`, the `validateFields()` of the trait is never called, because the `validateFields()` of the ActionRequest never calls it.
I also fixed a minor bug where `fieldsForValidation()` would not return the resulting array.
