### PR TITLE
Fix phpdoc types in class HasChildFields

### DIFF
--- a/src/HasChildFields.php
+++ b/src/HasChildFields.php
@@ -7,7 +7,7 @@ trait HasChildFields
     protected $childFieldsArr = [];
 
     /**
-     * @param  [array] $childFields [meta fields]
+     * @param  array $childFields meta fields
      * @return void
      */
     protected function extractChildFields($childFields)
@@ -26,8 +26,8 @@ trait HasChildFields
     }
 
     /**
-     * @param  [array] $childField
-     * @return [array] $childField
+     * @param  array $childField
+     * @return array $childField
      */
     protected function applyRulesForChildFields($childField)
     {


### PR DESCRIPTION
Phpdoc for methods in `HasChildFields` is not in a valid format, thus static analysis tools report `[array]` as an invalid type.