### PR TITLE
Add ability to depend on BelongsTo values

### DIFF
--- a/src/NovaDependencyContainer.php
+++ b/src/NovaDependencyContainer.php
@@ -153,28 +153,30 @@ class NovaDependencyContainer extends Field
 
             $this->meta['dependencies'][$index]['satisfied'] = false;
 
-            if (array_key_exists('empty', $dependency) && empty($resource->{$dependency['property']})) {
+            $propertyValue = $resource->{$dependency['field']}->{$dependency['property']} ?? $resource->{$dependency['property']};
+
+            if (array_key_exists('empty', $dependency) && empty($propertyValue)) {
                 $this->meta['dependencies'][$index]['satisfied'] = true;
                 continue;
             }
             // inverted `empty()`
-            if (array_key_exists('notEmpty', $dependency) && !empty($resource->{$dependency['property']})) {
+            if (array_key_exists('notEmpty', $dependency) && !empty($propertyValue)) {
                 $this->meta['dependencies'][$index]['satisfied'] = true;
                 continue;
             }
             // inverted
-            if (array_key_exists('nullOrZero', $dependency) && in_array($resource->{$dependency['property']}, [null, 0, '0'], true)) {
+            if (array_key_exists('nullOrZero', $dependency) && in_array($propertyValue, [null, 0, '0'], true)) {
                 $this->meta['dependencies'][$index]['satisfied'] = true;
                 continue;
             }
 
-            if (array_key_exists('not', $dependency) && $resource->{$dependency['property']} != $dependency['not']) {
+            if (array_key_exists('not', $dependency) && ($propertyValue != $dependency['not'])) {
                 $this->meta['dependencies'][$index]['satisfied'] = true;
                 continue;
             }
 
             if (array_key_exists('value', $dependency)) {
-                if ($dependency['value'] == $resource->{$dependency['property']}) {
+                if ($dependency['value'] == $propertyValue) {
                     $this->meta['dependencies'][$index]['satisfied'] = true;
                     continue;
                 }


### PR DESCRIPTION
This PR addresses the issue in https://github.com/epartment/nova-dependency-container/issues/133.

Each dependency that is registered is stored in `$this->meta['dependencies']` in NovaDependencyContainer with the following attributes:

```
[
  'field' => 'user',
  'property' => 'email'
]
```

The `property` attribute is currently being used to fetch the value when determining whether to display a group of fields.

This PR modifies `resolveForDisplay` to also check the field's property to determine visibility.